### PR TITLE
Fix terminal line height for ASCII art and modernize Android build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,10 +12,10 @@ local.properties
 captures/
 .externalNativeBuild/
 .cxx/
+.cargo
 features.html
 
 # Scripts
-build_android.sh
 run_android.sh
 
 # Android specific
@@ -23,8 +23,11 @@ android/build/
 android/app/build/
 android/.gradle/
 android/app/src/main/jniLibs/
+android/gradle/gradle-daemon-jvm.properties
+
 
 # Keystores and secrets
 *.keystore
 *.jks
 keystore-b64.txt
+android/android/app/src/main/jniLibs/arm64-v8a/librpkg.so

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ It provides **seamless terminal access and robust package management** on Androi
 
 - Android Studio (latest version)
 - Android SDK (API 31+)
-- Rust toolchain (with `aarch64-linux-android` target)
-- NDK 26.1.10909125
+- Rust toolchain with `cargo-ndk` installed
+- NDK 28.2.13676358 (or compatible version)
 
 ### Local Development
 
@@ -53,25 +53,38 @@ It provides **seamless terminal access and robust package management** on Androi
    cd Rin
    ```
 
-2. Setup configuration files:
+2. Install `cargo-ndk` (required for building Rust libraries for Android):
 
    ```bash
-   cp local.properties.template local.properties
-   cp gradle.properties.template gradle.properties
+   cargo install cargo-ndk
    ```
 
-3. Edit `local.properties` with your Android SDK and NDK paths:
+3. Set up Android NDK environment variable:
 
-   ```properties
-   sdk.dir=/path/to/your/android/sdk
-   ndk.dir=/path/to/your/android/ndk/26.1.10909125
+   **Linux/macOS:**
+   ```bash
+   export ANDROID_NDK_HOME=/path/to/your/android/sdk/ndk/28.2.13676358
    ```
 
-4. Build the Rust JNI binary via cargo and compile the APK:
+   **Windows:**
+   ```cmd
+   set ANDROID_NDK_HOME=C:\Users\YourName\AppData\Local\Android\Sdk\ndk\28.2.13676358
+   ```
+
+4. Build the Rust JNI binary and compile the APK:
+
+   **Linux/macOS:**
    ```bash
    ./build_android.sh
    cd android
    ./gradlew assembleDebug
+   ```
+
+   **Windows:**
+   ```cmd
+   build_android.bat
+   cd android
+   gradlew.bat assembleDebug
    ```
 
 ### Security Notice

--- a/android/app/src/main/kotlin/com/rin/ui/components/TerminalSurface.kt
+++ b/android/app/src/main/kotlin/com/rin/ui/components/TerminalSurface.kt
@@ -35,7 +35,7 @@ fun TerminalSurface(
     modifier: Modifier = Modifier,
     onInput: (ByteArray) -> Unit = {}
 ) {
-    var fontSize by remember { mutableFloatStateOf(13f) } // Reduced from 18f
+    var fontSize by remember { mutableFloatStateOf(11f) }
     var ctrlState by remember { mutableStateOf(ctrlPressed) }
     var cursorVisible by remember { mutableStateOf(true) }
     val colorScheme = rememberTerminalColorScheme()
@@ -115,7 +115,10 @@ private class TerminalCanvasView(context: Context) : View(context) {
         get() = textPaint.measureText("W")
 
     private val lineHeight: Float
-        get() = textPaint.fontSpacing
+        get() {
+            val metrics = textPaint.fontMetrics
+            return metrics.descent - metrics.ascent
+        }
 
     private val scaleDetector = ScaleGestureDetector(context, object : ScaleGestureDetector.SimpleOnScaleGestureListener() {
         override fun onScale(detector: ScaleGestureDetector): Boolean {
@@ -133,13 +136,13 @@ private class TerminalCanvasView(context: Context) : View(context) {
         isFocusable = true
         isFocusableInTouchMode = true
         updatePaint()
-        
-        // Refresh at ~30fps for cursor blink and terminal updates
-        // Battery-friendly compared to 60fps while still responsive
+    
         postDelayed(object : Runnable {
             override fun run() {
-                invalidate()
-                postDelayed(this, 33) // ~30fps
+                if (engineHandle != 0L && RinLib.hasDirtyRows(engineHandle)) {
+                    invalidate()
+                }
+                postDelayed(this, 33)
             }
         }, 33)
     }

--- a/build_android.bat
+++ b/build_android.bat
@@ -1,0 +1,102 @@
+@echo off
+setlocal enabledelayedexpansion
+
+echo Building Rin for Android...
+
+REM Check if cargo is installed
+where cargo >nul 2>nul
+if %ERRORLEVEL% NEQ 0 (
+    echo Error: Rust/Cargo not found. Please install Rust from https://rustup.rs/
+    exit /b 1
+)
+
+REM Check if Android NDK is configured
+if "%ANDROID_NDK_HOME%"=="" (
+    if "%NDK_HOME%"=="" (
+        echo Error: ANDROID_NDK_HOME or NDK_HOME environment variable not set
+        echo Please set it to your NDK path, e.g.:
+        echo set ANDROID_NDK_HOME=C:\Users\YourName\AppData\Local\Android\Sdk\ndk\26.1.10909125
+        exit /b 1
+    )
+    set NDK_PATH=%NDK_HOME%
+) else (
+    set NDK_PATH=%ANDROID_NDK_HOME%
+)
+
+echo Using NDK: %NDK_PATH%
+
+REM Set up NDK toolchain paths and environment variables
+set PATH=%NDK_PATH%\toolchains\llvm\prebuilt\windows-x86_64\bin;%PATH%
+set CC=%NDK_PATH%\toolchains\llvm\prebuilt\windows-x86_64\bin\clang.exe --target=aarch64-linux-android24
+set AR=%NDK_PATH%\toolchains\llvm\prebuilt\windows-x86_64\bin\llvm-ar.exe
+set CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=%NDK_PATH%\toolchains\llvm\prebuilt\windows-x86_64\bin\clang.exe
+
+REM Build for ARM64 (primary target)
+echo.
+echo Building for aarch64-linux-android...
+cargo ndk -t arm64-v8a -o android/app/src/main/jniLibs build --release --features android --lib
+if %ERRORLEVEL% NEQ 0 (
+    echo Build failed for aarch64-linux-android
+    exit /b 1
+)
+
+REM Build rpkg CLI for ARM64
+echo.
+echo Building rpkg CLI for aarch64-linux-android...
+cargo ndk -t arm64-v8a build --release --package rpkg --bin rpkg
+if %ERRORLEVEL% NEQ 0 (
+    echo Build failed for rpkg CLI
+    exit /b 1
+)
+
+REM Copy and rename rpkg binary to librpkg_cli.so for Android
+if not exist "android\app\src\main\jniLibs\arm64-v8a" mkdir "android\app\src\main\jniLibs\arm64-v8a"
+copy /Y "target\aarch64-linux-android\release\rpkg" "android\app\src\main\jniLibs\arm64-v8a\librpkg_cli.so"
+
+REM Build for ARMv7
+echo.
+echo Building for armv7-linux-androideabi...
+cargo ndk -t armeabi-v7a -o android/app/src/main/jniLibs build --release --features android --lib
+if %ERRORLEVEL% NEQ 0 (
+    echo Build failed for armv7-linux-androideabi
+    exit /b 1
+)
+
+REM Build rpkg CLI for ARMv7
+echo.
+echo Building rpkg CLI for armv7-linux-androideabi...
+cargo ndk -t armeabi-v7a build --release --package rpkg --bin rpkg
+if %ERRORLEVEL% NEQ 0 (
+    echo Build failed for rpkg CLI
+    exit /b 1
+)
+
+if not exist "android\app\src\main\jniLibs\armeabi-v7a" mkdir "android\app\src\main\jniLibs\armeabi-v7a"
+copy /Y "target\armv7-linux-androideabi\release\rpkg" "android\app\src\main\jniLibs\armeabi-v7a\librpkg_cli.so"
+
+REM Build for x86_64 (emulator)
+echo.
+echo Building for x86_64-linux-android...
+cargo ndk -t x86_64 -o android/app/src/main/jniLibs build --release --features android --lib
+if %ERRORLEVEL% NEQ 0 (
+    echo Build failed for x86_64-linux-android
+    exit /b 1
+)
+
+REM Build rpkg CLI for x86_64
+echo.
+echo Building rpkg CLI for x86_64-linux-android...
+cargo ndk -t x86_64 build --release --package rpkg --bin rpkg
+if %ERRORLEVEL% NEQ 0 (
+    echo Build failed for rpkg CLI
+    exit /b 1
+)
+
+if not exist "android\app\src\main\jniLibs\x86_64" mkdir "android\app\src\main\jniLibs\x86_64"
+copy /Y "target\x86_64-linux-android\release\rpkg" "android\app\src\main\jniLibs\x86_64\librpkg_cli.so"
+
+echo.
+echo ========================================
+echo Build complete! Libraries copied to jniLibs/
+echo Now run: cd android ^&^& gradlew.bat assembleDebug
+echo ========================================

--- a/build_android.sh
+++ b/build_android.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+set -e
+
+echo "Building Rin for Android..."
+
+# Check if cargo is installed
+if ! command -v cargo &> /dev/null; then
+    echo "Error: Rust/Cargo not found. Please install Rust from https://rustup.rs/"
+    exit 1
+fi
+
+# Check if cargo-ndk is installed
+if ! command -v cargo-ndk &> /dev/null; then
+    echo "Error: cargo-ndk not found. Installing..."
+    cargo install cargo-ndk
+fi
+
+# Check if Android NDK is configured
+if [ -z "$ANDROID_NDK_HOME" ] && [ -z "$NDK_HOME" ]; then
+    echo "Error: ANDROID_NDK_HOME or NDK_HOME environment variable not set"
+    echo "Please set it to your NDK path, e.g.:"
+    echo "export ANDROID_NDK_HOME=/path/to/ndk/28.2.13676358"
+    exit 1
+fi
+
+NDK_PATH="${ANDROID_NDK_HOME:-$NDK_HOME}"
+echo "Using NDK: $NDK_PATH"
+
+# Build for ARM64 (primary target)
+echo ""
+echo "Building for aarch64-linux-android..."
+cargo ndk -t arm64-v8a -o android/app/src/main/jniLibs build --release --features android --lib
+if [ $? -ne 0 ]; then
+    echo "Build failed for aarch64-linux-android"
+    exit 1
+fi
+
+# Build rpkg CLI for ARM64
+echo ""
+echo "Building rpkg CLI for aarch64-linux-android..."
+cargo ndk -t arm64-v8a build --release --package rpkg --bin rpkg
+if [ $? -ne 0 ]; then
+    echo "Build failed for rpkg CLI"
+    exit 1
+fi
+
+# Copy and rename rpkg binary to librpkg_cli.so for Android
+mkdir -p android/app/src/main/jniLibs/arm64-v8a
+cp target/aarch64-linux-android/release/rpkg android/app/src/main/jniLibs/arm64-v8a/librpkg_cli.so
+
+# Build for ARMv7
+echo ""
+echo "Building for armv7-linux-androideabi..."
+cargo ndk -t armeabi-v7a -o android/app/src/main/jniLibs build --release --features android --lib
+if [ $? -ne 0 ]; then
+    echo "Build failed for armv7-linux-androideabi"
+    exit 1
+fi
+
+# Build rpkg CLI for ARMv7
+echo ""
+echo "Building rpkg CLI for armv7-linux-androideabi..."
+cargo ndk -t armeabi-v7a build --release --package rpkg --bin rpkg
+if [ $? -ne 0 ]; then
+    echo "Build failed for rpkg CLI"
+    exit 1
+fi
+
+mkdir -p android/app/src/main/jniLibs/armeabi-v7a
+cp target/armv7-linux-androideabi/release/rpkg android/app/src/main/jniLibs/armeabi-v7a/librpkg_cli.so
+
+# Build for x86_64 (emulator)
+echo ""
+echo "Building for x86_64-linux-android..."
+cargo ndk -t x86_64 -o android/app/src/main/jniLibs build --release --features android --lib
+if [ $? -ne 0 ]; then
+    echo "Build failed for x86_64-linux-android"
+    exit 1
+fi
+
+# Build rpkg CLI for x86_64
+echo ""
+echo "Building rpkg CLI for x86_64-linux-android..."
+cargo ndk -t x86_64 build --release --package rpkg --bin rpkg
+if [ $? -ne 0 ]; then
+    echo "Build failed for rpkg CLI"
+    exit 1
+fi
+
+mkdir -p android/app/src/main/jniLibs/x86_64
+cp target/x86_64-linux-android/release/rpkg android/app/src/main/jniLibs/x86_64/librpkg_cli.so
+
+echo ""
+echo "========================================"
+echo "Build complete! Libraries copied to jniLibs/"
+echo "Now run: cd android && ./gradlew assembleDebug"
+echo "========================================"

--- a/src/android.rs
+++ b/src/android.rs
@@ -121,13 +121,11 @@ pub extern "system" fn Java_com_rin_RinLib_createEngine(
             return -1;
         }
     };
-
-    // 3. Spawn Reader Thread (PTY -> Engine)
     let pty_clone = pty.clone();
     let engine_clone = engine.clone();
 
     thread::spawn(move || {
-        let mut buffer = [0u8; 4096];
+        let mut buffer = [0u8; 16384];
         let mut reader = {
             let mut pty_guard = pty_clone.lock().unwrap();
             match pty_guard.take_reader() {
@@ -140,12 +138,15 @@ pub extern "system" fn Java_com_rin_RinLib_createEngine(
         };
 
         loop {
+            // Blocking read
             match reader.read(&mut buffer) {
                 Ok(0) => {
                     log::info!("PTY closed (EOF)");
                     break;
                 }
                 Ok(n) => {
+                    thread::sleep(std::time::Duration::from_millis(2));
+
                     let mut engine_guard = engine_clone.lock().unwrap();
                     if let Err(e) = engine_guard.write(&buffer[..n]) {
                         log::error!("Failed to write to engine: {}", e);

--- a/src/core/buffer.rs
+++ b/src/core/buffer.rs
@@ -220,13 +220,14 @@ impl TerminalBuffer {
         }
 
         // Handle line wrap
-        // Handle line wrap
         if self.cursor_x >= self.grid.width() {
             if self.auto_wrap_mode {
                 self.cursor_x = 0;
-                self.cursor_y += 1;
-                if self.cursor_y >= self.grid.height() {
+                let (_, bottom) = self.effective_scroll_region();
+                if self.cursor_y >= bottom {
                     self.scroll_up(1);
+                } else {
+                    self.cursor_y += 1;
                 }
             } else {
                 self.cursor_x = self.grid.width().saturating_sub(1);
@@ -247,21 +248,30 @@ impl TerminalBuffer {
         self.cursor_x = width.saturating_sub(1);
     }
 
+    /// Returns (top, bottom) of the effective scroll region, defaulting to full screen.
+    fn effective_scroll_region(&self) -> (usize, usize) {
+        let height = self.grid.height();
+        self.scroll_region
+            .map(|(t, b)| (t, b.min(height.saturating_sub(1))))
+            .unwrap_or((0, height.saturating_sub(1)))
+    }
+
     fn scroll_up(&mut self, n: usize) {
         let width = self.grid.width();
-        let height = self.grid.height();
+        let (top, bottom) = self.effective_scroll_region();
 
-        for y in 0..n.min(height) {
-            if let Some(row) = self.grid.row(y) {
-                self.scrollback.push_back(row.to_vec());
+        if top == 0 && bottom == self.grid.height().saturating_sub(1) {
+            for y in 0..n.min(bottom + 1) {
+                if let Some(row) = self.grid.row(y) {
+                    self.scrollback.push_back(row.to_vec());
+                }
+            }
+            while self.scrollback.len() > self.scrollback_limit {
+                self.scrollback.pop_front();
             }
         }
 
-        while self.scrollback.len() > self.scrollback_limit {
-            self.scrollback.pop_front();
-        }
-
-        for y in n..height {
+        for y in (top + n)..=bottom {
             for x in 0..width {
                 if let Some(cell) = self.grid.get(x, y).cloned() {
                     let _ = self.grid.set(x, y - n, cell);
@@ -269,20 +279,47 @@ impl TerminalBuffer {
             }
         }
 
-        for y in (height.saturating_sub(n))..height {
+        let clear_start = if bottom + 1 >= n { bottom + 1 - n } else { top };
+        for y in clear_start..=bottom {
             for x in 0..width {
                 let _ = self.grid.set(x, y, Cell::default());
             }
         }
 
-        self.cursor_y = self.cursor_y.saturating_sub(n);
+        if top == 0 && bottom == self.grid.height().saturating_sub(1) {
+            self.cursor_y = self.cursor_y.saturating_sub(n);
+        }
     }
 
     fn scroll_down(&mut self, n: usize) {
         let width = self.grid.width();
-        let height = self.grid.height();
+        let (top, bottom) = self.effective_scroll_region();
 
-        for y in (0..(height - n)).rev() {
+        for y in (top..=(bottom.saturating_sub(n))).rev() {
+            for x in 0..width {
+                if let Some(cell) = self.grid.get(x, y).cloned() {
+                    let _ = self.grid.set(x, y + n, cell);
+                }
+            }
+        }
+        for y in top..=(top + n - 1).min(bottom) {
+            for x in 0..width {
+                let _ = self.grid.set(x, y, Cell::default());
+            }
+        }
+    }
+
+    fn insert_lines_at_cursor(&mut self, n: usize) {
+        let width = self.grid.width();
+        let (_, bottom) = self.effective_scroll_region();
+        let start = self.cursor_y;
+
+        if start > bottom {
+            return;
+        }
+
+        // Shift rows
+        for y in (start..=(bottom.saturating_sub(n))).rev() {
             for x in 0..width {
                 if let Some(cell) = self.grid.get(x, y).cloned() {
                     let _ = self.grid.set(x, y + n, cell);
@@ -290,7 +327,33 @@ impl TerminalBuffer {
             }
         }
 
-        for y in 0..n.min(height) {
+        // Clear the n lines at cursor
+        for y in start..(start + n).min(bottom + 1) {
+            for x in 0..width {
+                let _ = self.grid.set(x, y, Cell::default());
+            }
+        }
+    }
+
+    fn delete_lines_at_cursor(&mut self, n: usize) {
+        let width = self.grid.width();
+        let (_, bottom) = self.effective_scroll_region();
+        let start = self.cursor_y;
+
+        if start > bottom {
+            return;
+        }
+
+        for y in (start + n)..=bottom {
+            for x in 0..width {
+                if let Some(cell) = self.grid.get(x, y).cloned() {
+                    let _ = self.grid.set(x, y - n, cell);
+                }
+            }
+        }
+
+        let clear_start = if bottom + 1 >= n { bottom + 1 - n } else { start };
+        for y in clear_start..=bottom {
             for x in 0..width {
                 let _ = self.grid.set(x, y, Cell::default());
             }
@@ -301,10 +364,11 @@ impl TerminalBuffer {
         match cmd {
             Command::Print(c) => {
                 if c == '\n' {
-                    self.cursor_x = 0;
-                    self.cursor_y += 1;
-                    if self.cursor_y >= self.grid.height() {
+                    let (_, bottom) = self.effective_scroll_region();
+                    if self.cursor_y >= bottom {
                         self.scroll_up(1);
+                    } else {
+                        self.cursor_y += 1;
                     }
                 } else if c == '\r' {
                     self.cursor_x = 0;
@@ -316,10 +380,11 @@ impl TerminalBuffer {
             }
             Command::Execute(byte) => match byte {
                 b'\n' => {
-                    self.cursor_x = 0;
-                    self.cursor_y += 1;
-                    if self.cursor_y >= self.grid.height() {
+                    let (_, bottom) = self.effective_scroll_region();
+                    if self.cursor_y >= bottom {
                         self.scroll_up(1);
+                    } else {
+                        self.cursor_y += 1;
                     }
                 }
                 b'\r' => self.cursor_x = 0,
@@ -442,10 +507,10 @@ impl TerminalBuffer {
                 self.scroll_down(n);
             }
             Command::InsertLine(n) => {
-                self.scroll_down(n);
+                self.insert_lines_at_cursor(n);
             }
             Command::DeleteLine(n) => {
-                self.scroll_up(n);
+                self.delete_lines_at_cursor(n);
             }
             Command::EraseChars(n) => {
                 for i in 0..n {
@@ -579,6 +644,33 @@ impl TerminalBuffer {
             }
             Command::CopyToClipboard(content) => {
                 self.pending_clipboard.push(content);
+            }
+            Command::MoveCursorToRow(row) => {
+                // VPA
+                self.cursor_y = row.min(self.grid.height().saturating_sub(1));
+            }
+            Command::MoveCursorToColumn(col) => {
+                // CHA/HPA
+                self.cursor_x = col.min(self.grid.width().saturating_sub(1));
+            }
+            Command::CursorNextLine(n) => {
+                // CNL
+                self.cursor_x = 0;
+                self.cursor_y = (self.cursor_y + n).min(self.grid.height().saturating_sub(1));
+            }
+            Command::CursorPreviousLine(n) => {
+                // CPL
+                self.cursor_x = 0;
+                self.cursor_y = self.cursor_y.saturating_sub(n);
+            }
+            Command::ReverseIndex => {
+                // RI (ESC M)
+                let (top, _) = self.effective_scroll_region();
+                if self.cursor_y <= top {
+                    self.scroll_down(1);
+                } else {
+                    self.cursor_y -= 1;
+                }
             }
         }
         Ok(())

--- a/src/parser/ansi.rs
+++ b/src/parser/ansi.rs
@@ -64,6 +64,11 @@ pub enum Command {
     SetOriginMode(bool),
     SetAutoWrapMode(bool),
     CopyToClipboard(String),
+    MoveCursorToRow(usize),
+    MoveCursorToColumn(usize),
+    CursorNextLine(usize),
+    CursorPreviousLine(usize),
+    ReverseIndex,
 }
 
 /// Mouse tracking modes
@@ -311,6 +316,31 @@ impl Perform for AnsiPerformer {
                     },
                 });
             }
+            'd' => {
+                // VPA - Vertical Position Absolute
+                let n = *params.iter().next().and_then(|p| p.first()).unwrap_or(&1);
+                self.commands.push(Command::MoveCursorToRow(n.saturating_sub(1) as usize));
+            }
+            'G' | '`' => {
+                // CHA / HPA - Cursor Character/Horizontal Absolute
+                let n = *params.iter().next().and_then(|p| p.first()).unwrap_or(&1);
+                self.commands.push(Command::MoveCursorToColumn(n.saturating_sub(1) as usize));
+            }
+            'E' => {
+                // CNL - Cursor Next Line
+                let n = *params.iter().next().and_then(|p| p.first()).unwrap_or(&1) as usize;
+                self.commands.push(Command::CursorNextLine(n));
+            }
+            'F' => {
+                // CPL - Cursor Previous Line
+                let n = *params.iter().next().and_then(|p| p.first()).unwrap_or(&1) as usize;
+                self.commands.push(Command::CursorPreviousLine(n));
+            }
+            'X' => {
+                // ECH - Erase Character
+                let n = *params.iter().next().and_then(|p| p.first()).unwrap_or(&1) as usize;
+                self.commands.push(Command::EraseChars(n));
+            }
             _ => {}
         }
     }
@@ -331,11 +361,16 @@ impl Perform for AnsiPerformer {
             }
         }
 
-        match byte {
+         match byte {
             b'c' => self.commands.push(Command::Reset),
             b'7' => self.commands.push(Command::SaveCursor), // DECSC
             b'8' => self.commands.push(Command::RestoreCursor), // DECRC
             b'H' => self.commands.push(Command::SetTabStop), // HTS
+            b'M' => self.commands.push(Command::ReverseIndex), // RI
+            b'D' => {
+                // IND - Index
+                self.commands.push(Command::Execute(b'\n'));
+            }
             _ => {}
         }
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -308,3 +308,137 @@ mod priority_feature_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod scroll_region_tests {
+    use crate::core::TerminalBuffer;
+    use crate::parser::Command;
+
+    fn put_char(buf: &mut TerminalBuffer, x: usize, y: usize, c: char) {
+        buf.execute_command(Command::MoveCursor(x, y)).unwrap();
+        buf.write_char(c).unwrap();
+    }
+
+    fn get_char(buf: &TerminalBuffer, x: usize, y: usize) -> char {
+        buf.grid().get(x, y).map(|c| c.character).unwrap_or(' ')
+    }
+
+    #[test]
+    fn test_scroll_region_scroll_up() {
+        let mut buf = TerminalBuffer::new(10, 8);
+
+        // Put identifiable chars in rows 2-5
+        put_char(&mut buf, 0, 2, 'A');
+        put_char(&mut buf, 0, 3, 'B');
+        put_char(&mut buf, 0, 4, 'C');
+        put_char(&mut buf, 0, 5, 'D');
+        // Put a char outside the region
+        put_char(&mut buf, 0, 0, 'Z');
+        put_char(&mut buf, 0, 7, 'Y');
+
+        // Set scroll region to rows 2-5 (1-indexed: 3-6)
+        buf.execute_command(Command::SetScrollRegion { top: 2, bottom: 5 })
+            .unwrap();
+        buf.execute_command(Command::ScrollUp(1)).unwrap();
+
+        // Row 0 and 7 should be untouched
+        assert_eq!(get_char(&buf, 0, 0), 'Z');
+        assert_eq!(get_char(&buf, 0, 7), 'Y');
+        assert_eq!(get_char(&buf, 0, 2), 'B');
+        assert_eq!(get_char(&buf, 0, 3), 'C');
+        assert_eq!(get_char(&buf, 0, 4), 'D');
+        assert_eq!(get_char(&buf, 0, 5), ' ');
+    }
+
+    #[test]
+    fn test_scroll_region_scroll_down() {
+        let mut buf = TerminalBuffer::new(10, 8);
+
+        put_char(&mut buf, 0, 2, 'A');
+        put_char(&mut buf, 0, 3, 'B');
+        put_char(&mut buf, 0, 4, 'C');
+        put_char(&mut buf, 0, 5, 'D');
+        put_char(&mut buf, 0, 0, 'Z');
+
+        buf.execute_command(Command::SetScrollRegion { top: 2, bottom: 5 })
+            .unwrap();
+        buf.execute_command(Command::ScrollDown(1)).unwrap();
+
+        assert_eq!(get_char(&buf, 0, 0), 'Z');
+        assert_eq!(get_char(&buf, 0, 2), ' ');
+        assert_eq!(get_char(&buf, 0, 3), 'A');
+        assert_eq!(get_char(&buf, 0, 4), 'B');
+        assert_eq!(get_char(&buf, 0, 5), 'C');
+    }
+
+    #[test]
+    fn test_insert_line_at_cursor() {
+        let mut buf = TerminalBuffer::new(10, 8);
+
+        put_char(&mut buf, 0, 1, 'A');
+        put_char(&mut buf, 0, 2, 'B');
+        put_char(&mut buf, 0, 3, 'C');
+        put_char(&mut buf, 0, 5, 'E');
+
+        buf.execute_command(Command::SetScrollRegion { top: 1, bottom: 5 })
+            .unwrap();
+        // Move cursor to row 2  
+        buf.execute_command(Command::MoveCursor(0, 2)).unwrap();
+        buf.execute_command(Command::InsertLine(1)).unwrap();
+
+        // Row 1 untouched
+        assert_eq!(get_char(&buf, 0, 1), 'A');
+        // Row 2 should be blank
+        assert_eq!(get_char(&buf, 0, 2), ' ');
+        // B shifted to row 3, C to row 4
+        assert_eq!(get_char(&buf, 0, 3), 'B');
+        assert_eq!(get_char(&buf, 0, 4), 'C');
+        // E was at row 5 but row 4 shifts to row 5, overwriting E
+        assert_eq!(get_char(&buf, 0, 5), ' ');
+    }
+
+    #[test]
+    fn test_delete_line_at_cursor() {
+        let mut buf = TerminalBuffer::new(10, 8);
+
+        put_char(&mut buf, 0, 1, 'A');
+        put_char(&mut buf, 0, 2, 'B');
+        put_char(&mut buf, 0, 3, 'C');
+        put_char(&mut buf, 0, 4, 'D');
+
+        buf.execute_command(Command::SetScrollRegion { top: 1, bottom: 4 })
+            .unwrap();
+        buf.execute_command(Command::MoveCursor(0, 2)).unwrap();
+        buf.execute_command(Command::DeleteLine(1)).unwrap();
+
+        // Row 1 untouched
+        assert_eq!(get_char(&buf, 0, 1), 'A');
+        assert_eq!(get_char(&buf, 0, 2), 'C');
+        assert_eq!(get_char(&buf, 0, 3), 'D');
+        assert_eq!(get_char(&buf, 0, 4), ' ');
+    }
+
+    #[test]
+    fn test_newline_at_scroll_region_bottom() {
+        let mut buf = TerminalBuffer::new(10, 8);
+
+        put_char(&mut buf, 0, 2, 'A');
+        put_char(&mut buf, 0, 3, 'B');
+        put_char(&mut buf, 0, 4, 'C');
+        // Outside region
+        put_char(&mut buf, 0, 0, 'Z');
+        put_char(&mut buf, 0, 7, 'Y');
+
+        buf.execute_command(Command::SetScrollRegion { top: 2, bottom: 4 })
+            .unwrap();
+        buf.execute_command(Command::MoveCursor(0, 4)).unwrap();
+        buf.execute_command(Command::Print('\n')).unwrap();
+
+        // Outside region untouched
+        assert_eq!(get_char(&buf, 0, 0), 'Z');
+        assert_eq!(get_char(&buf, 0, 7), 'Y');
+        assert_eq!(get_char(&buf, 0, 2), 'B');
+        assert_eq!(get_char(&buf, 0, 3), 'C');
+        assert_eq!(get_char(&buf, 0, 4), ' ');
+    }
+}


### PR DESCRIPTION
## Summary
Fixes ASCII art rendering and modernizes build system with cargo-ndk.

## Key Changes
- Fixed terminal line height using font metrics (fixes ASCII art like `sl`)
- Reduced default font size to 11sp for better column width
- Migrated to cargo-ndk for simpler, cross-platform builds
- Added rpkg CLI binary build for package management
- Updated build scripts and documentation
- Raise Buffer For 4KB to 16KB

## Testing
Tested on Windows with NDK 28.2.13676358. ASCII art now renders correctly.

# Notes
> Maybe Animation ASCII SL has a little jitter but it doesn't affect the neatness

# Screenshot
<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/e9c3e32b-d609-432f-8567-39adce2062c2" />
